### PR TITLE
fix: performance regression for filtering ListView (#5390)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9371,6 +9371,7 @@ dependencies = [
 name = "vortex-zstd"
 version = "0.1.0"
 dependencies = [
+ "codspeed-divan-compat",
  "itertools 0.14.0",
  "prost 0.14.1",
  "rstest",

--- a/encodings/zstd/Cargo.toml
+++ b/encodings/zstd/Cargo.toml
@@ -30,5 +30,10 @@ vortex-vector = { workspace = true }
 zstd = { workspace = true }
 
 [dev-dependencies]
+divan = { workspace = true }
 rstest = { workspace = true }
 vortex-array = { workspace = true, features = ["test-harness"] }
+
+[[bench]]
+name = "listview_rebuild"
+harness = false

--- a/encodings/zstd/benches/listview_rebuild.rs
+++ b/encodings/zstd/benches/listview_rebuild.rs
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+#![allow(clippy::unwrap_used)]
+
+use divan::Bencher;
+use vortex_array::IntoArray;
+use vortex_array::arrays::{ListViewArray, ListViewRebuildMode, VarBinViewArray};
+use vortex_array::validity::Validity;
+use vortex_buffer::Buffer;
+use vortex_zstd::ZstdArray;
+
+#[divan::bench]
+fn rebuild_naive(bencher: Bencher) {
+    let dudes = VarBinViewArray::from_iter_str(["Washington", "Adams", "Jefferson", "Madison"])
+        .into_array();
+    let dudes = ZstdArray::from_array(dudes, 9, 1024).unwrap().into_array();
+
+    let offsets = std::iter::repeat_n(0u32, 1024)
+        .collect::<Buffer<u32>>()
+        .into_array();
+    let sizes = [0u64, 1, 2, 3, 4]
+        .into_iter()
+        .cycle()
+        .take(1024)
+        .collect::<Buffer<u64>>()
+        .into_array();
+
+    let list_view = ListViewArray::new(dudes, offsets, sizes, Validity::NonNullable);
+
+    bencher.bench_local(|| list_view.rebuild(ListViewRebuildMode::MakeZeroCopyToList))
+}
+
+fn main() {
+    divan::main()
+}

--- a/encodings/zstd/benches/listview_rebuild.rs
+++ b/encodings/zstd/benches/listview_rebuild.rs
@@ -10,7 +10,7 @@ use vortex_array::validity::Validity;
 use vortex_buffer::Buffer;
 use vortex_zstd::ZstdArray;
 
-#[divan::bench]
+#[divan::bench(sample_size = 1000)]
 fn rebuild_naive(bencher: Bencher) {
     let dudes = VarBinViewArray::from_iter_str(["Washington", "Adams", "Jefferson", "Madison"])
         .into_array();

--- a/vortex-array/src/arrays/listview/array.rs
+++ b/vortex-array/src/arrays/listview/array.rs
@@ -99,8 +99,9 @@ pub struct ListViewArray {
     ///
     /// We use this information to help us more efficiently rebuild / compact our data.
     ///
-    /// When this flag is true (indicating sorted offsets with no gaps and no overlaps), conversions
-    /// can bypass the very expensive rebuild process (which just calls `append_scalar` in a loop).
+    /// When this flag is true (indicating sorted offsets with no gaps and no overlaps and all
+    /// `offsets[i] + sizes[i]` are in order), conversions can bypass the very expensive rebuild
+    /// process which must rebuild the array from scratch.
     is_zero_copy_to_list: bool,
 
     /// The validity / null map of the array.
@@ -264,6 +265,7 @@ impl ListViewArray {
     /// actually zero-copyable to a [`ListArray`]. This means:
     ///
     /// - Offsets must be sorted (but not strictly sorted, zero-length lists are allowed).
+    /// - `offsets[i] + sizes[i] == offsets[i + 1]` for all `i`.
     /// - No gaps in elements between first and last referenced elements.
     /// - No overlapping list views (each element referenced at most once).
     ///
@@ -425,7 +427,8 @@ where
         if offset_u64 == elements_len {
             vortex_ensure!(
                 size_u64 == 0,
-                "views to the end of the elements array (length {elements_len}) must have size 0"
+                "views to the end of the elements array (length {elements_len}) must have size 0 \
+                    (had size {size_u64})"
             );
         }
 
@@ -453,6 +456,51 @@ fn validate_zctl(
     } else {
         vortex_bail!("offsets must report is_sorted statistic");
     }
+
+    // Validate that offset[i] + size[i] <= offset[i+1] for all items
+    // This ensures views are non-overlapping and properly ordered for zero-copy-to-list
+    fn validate_monotonic_ends<O: IntegerPType, S: IntegerPType>(
+        offsets_slice: &[O],
+        sizes_slice: &[S],
+        len: usize,
+    ) -> VortexResult<()> {
+        let mut max_end = 0usize;
+
+        for i in 0..len {
+            let offset = offsets_slice[i].to_usize().unwrap_or(usize::MAX);
+            let size = sizes_slice[i].to_usize().unwrap_or(usize::MAX);
+
+            // Check that this view starts at or after the previous view ended
+            vortex_ensure!(
+                offset >= max_end,
+                "Zero-copy-to-list requires views to be non-overlapping and ordered: \
+                 view[{}] starts at {} but previous views extend to {}",
+                i,
+                offset,
+                max_end
+            );
+
+            // Update max_end for the next iteration
+            let end = offset.saturating_add(size);
+            max_end = max_end.max(end);
+        }
+
+        Ok(())
+    }
+
+    let offsets_dtype = offsets_primitive.dtype();
+    let sizes_dtype = sizes_primitive.dtype();
+    let len = offsets_primitive.len();
+
+    // Check that offset + size values are monotonic (no overlaps)
+    match_each_integer_ptype!(offsets_dtype.as_ptype(), |O| {
+        match_each_integer_ptype!(sizes_dtype.as_ptype(), |S| {
+            let offsets_slice = offsets_primitive.as_slice::<O>();
+            let sizes_slice = sizes_primitive.as_slice::<S>();
+
+            validate_monotonic_ends(offsets_slice, sizes_slice, len)?;
+        })
+    });
 
     // TODO(connor)[ListView]: Making this allocation is expensive, but the more efficient
     // implementation would be even more complicated than this. We could use a bit buffer denoting

--- a/vortex-array/src/arrays/listview/conversion.rs
+++ b/vortex-array/src/arrays/listview/conversion.rs
@@ -6,8 +6,10 @@ use std::sync::Arc;
 use vortex_dtype::{IntegerPType, Nullability, match_each_integer_ptype};
 use vortex_error::VortexExpect;
 
-use crate::arrays::{ExtensionArray, FixedSizeListArray, ListArray, ListViewArray, StructArray};
-use crate::builders::{ArrayBuilder, ListBuilder, PrimitiveBuilder};
+use crate::arrays::{
+    ExtensionArray, FixedSizeListArray, ListArray, ListViewArray, ListViewRebuildMode, StructArray,
+};
+use crate::builders::PrimitiveBuilder;
 use crate::vtable::ValidityHelper;
 use crate::{Array, ArrayRef, Canonical, IntoArray, ToCanonical};
 
@@ -92,56 +94,26 @@ fn build_sizes_from_offsets<O: IntegerPType>(list: &ListArray) -> ArrayRef {
 /// Otherwise, this function fall back to the (very) expensive path and will rebuild the
 /// [`ListArray`] from scratch.
 pub fn list_from_list_view(list_view: ListViewArray) -> ListArray {
-    // Fast path if the array is zero-copyable to a `ListArray`.
-    if list_view.is_zero_copy_to_list() {
-        let list_offsets = match_each_integer_ptype!(list_view.offsets().dtype().as_ptype(), |O| {
-            // SAFETY: We checked that the array is zero-copyable to `ListArray`, so the safety
-            // contract is upheld.
-            unsafe { build_list_offsets_from_list_view::<O>(&list_view) }
-        });
+    // Rebuild as zero-copyable to list array and also trim all leading and trailing elements.
+    let zctl_array = list_view.rebuild(ListViewRebuildMode::MakeExact);
+    debug_assert!(zctl_array.is_zero_copy_to_list());
 
-        // SAFETY: Because the shape of the `ListViewArray` is zero-copyable to a `ListArray`, we
-        // can simply reuse all of the data (besides the offsets).
-        let new_array = unsafe {
-            ListArray::new_unchecked(
-                list_view.elements().clone(),
-                list_offsets,
-                list_view.validity().clone(),
-            )
-        };
+    let list_offsets = match_each_integer_ptype!(zctl_array.offsets().dtype().as_ptype(), |O| {
+        // SAFETY: We just made the array zero-copyable to `ListArray`, so the safety contract is
+        // upheld.
+        unsafe { build_list_offsets_from_list_view::<O>(&zctl_array) }
+    });
 
-        let new_array = new_array
-            .reset_offsets(false)
-            .vortex_expect("TODO(connor)[ListView]: This can't fail");
-
-        return new_array;
+    // SAFETY: Because the shape of the `ListViewArray` is zero-copyable to a `ListArray`, we
+    // can simply reuse all of the data (besides the offsets). We also trim all of the elements to
+    // make it easier for the caller to use the `ListArray`.
+    unsafe {
+        ListArray::new_unchecked(
+            zctl_array.elements().clone(),
+            list_offsets,
+            zctl_array.validity().clone(),
+        )
     }
-
-    let elements_dtype = list_view
-        .dtype()
-        .as_list_element_opt()
-        .vortex_expect("`DType` of `ListView` was somehow not a `List`");
-    let nullability = list_view.dtype().nullability();
-    let len = list_view.len();
-
-    match_each_integer_ptype!(list_view.offsets().dtype().as_ptype(), |O| {
-        let mut builder = ListBuilder::<O>::with_capacity(
-            elements_dtype.clone(),
-            nullability,
-            list_view.elements().len(),
-            len,
-        );
-
-        for i in 0..len {
-            builder
-                .append_scalar(&list_view.scalar_at(i))
-                .vortex_expect(
-                    "The `ListView` scalars are `ListScalar`, which the `ListBuilder` must accept",
-                )
-        }
-
-        builder.finish_into_list()
-    })
 }
 
 // TODO(connor)[ListView]: We can optimize this by always keeping extra memory in `ListViewArray`
@@ -165,6 +137,7 @@ unsafe fn build_list_offsets_from_list_view<O: IntegerPType>(
 
     let offsets = list_view.offsets().to_primitive();
     let offsets_slice = offsets.as_slice::<O>();
+    debug_assert!(offsets_slice.is_sorted());
 
     // Copy the existing n offsets.
     offsets_range.copy_from_slice(0, offsets_slice);

--- a/vortex-array/src/arrays/listview/rebuild.rs
+++ b/vortex-array/src/arrays/listview/rebuild.rs
@@ -7,7 +7,8 @@ use vortex_dtype::{IntegerPType, Nullability, match_each_integer_ptype};
 use vortex_error::VortexExpect;
 use vortex_scalar::Scalar;
 
-use crate::arrays::{ChunkedArray, ListViewArray};
+use crate::arrays::ListViewArray;
+use crate::builders::builder_with_capacity;
 use crate::vtable::ValidityHelper;
 use crate::{Array, IntoArray, ToCanonical, compute};
 
@@ -74,6 +75,13 @@ impl ListViewArray {
         let offsets_ptype = self.offsets().dtype().as_ptype();
         let sizes_ptype = self.sizes().dtype().as_ptype();
 
+        // One of the main purposes behind adding this "zero-copyable to `ListArray`" optimization
+        // is that we want to pass data to systems that expect Arrow data.
+        // The arrow specification only allows for `i32` and `i64` offset and sizes types, so in
+        // order to also make `ListView` zero-copyable to **Arrow**'s `ListArray` (not just Vortex's
+        // `ListArray`), we rebuild the offsets as 32-bit or 64-bit integer types.
+        // TODO(connor)[ListView]: This is true for `sizes` as well, we should do this conversion
+        // for sizes as well.
         match_each_integer_ptype!(sizes_ptype, |S| {
             match offsets_ptype {
                 PType::U8 => self.naive_rebuild::<u8, u32, S>(),
@@ -89,8 +97,10 @@ impl ListViewArray {
         })
     }
 
-    /// The inner function for `rebuild_zero_copy_to_list`, which naively rebuilds a `ListViewArray`
-    /// via `append_scalar`.
+    // TODO(connor)[ListView]: We should benchmark if it is faster to use `take` on the elements
+    // instead of using a builder.
+    /// The inner function for `rebuild_zero_copy_to_list`, which rebuilds a `ListViewArray` piece
+    /// by piece.
     fn naive_rebuild<O: IntegerPType, NewOffset: IntegerPType, S: IntegerPType>(
         &self,
     ) -> ListViewArray {
@@ -99,59 +109,72 @@ impl ListViewArray {
             .as_list_element_opt()
             .vortex_expect("somehow had a canonical list that was not a list");
 
-        // Upfront canonicalize the list elements, we're going to be doing a lot of
-        // slicing with them.
-        let elements_canonical = self.elements().to_canonical().into_array();
         let offsets_canonical = self.offsets().to_primitive();
+        let offsets_slice = offsets_canonical.as_slice::<O>();
         let sizes_canonical = self.sizes().to_primitive();
+        let sizes_slice = sizes_canonical.as_slice::<S>();
 
-        let offsets_canonical = offsets_canonical.as_slice::<O>();
-        let sizes_canonical = sizes_canonical.as_slice::<S>();
+        let len = offsets_slice.len();
 
-        let mut offsets = BufferMut::<NewOffset>::with_capacity(self.len());
-        let mut sizes = BufferMut::<S>::with_capacity(self.len());
+        let mut new_offsets = BufferMut::<NewOffset>::with_capacity(len);
+        // TODO(connor)[ListView]: Do we really need to do this?
+        // The only reason we need to rebuild the sizes here is that the validity may indicate that
+        // a list is null even though it has a non-zero size. This rebuild will set the size of all
+        // null lists to 0.
+        let mut new_sizes = BufferMut::<S>::with_capacity(len);
 
-        let mut chunks = Vec::with_capacity(self.len());
+        // Canonicalize the elements up front as we will be slicing the elements quite a lot.
+        let elements_canonical = self.elements().to_canonical().into_array();
+
+        // Note that we do not know what the exact capacity should be of the new elements since
+        // there could be overlaps in the existing `ListViewArray`.
+        let mut new_elements_builder =
+            builder_with_capacity(element_dtype.as_ref(), self.elements().len());
 
         let mut n_elements = NewOffset::zero();
-
-        for index in 0..self.len() {
+        for index in 0..len {
             if !self.is_valid(index) {
-                offsets.push(offsets.last().copied().unwrap_or_default());
-                sizes.push(S::zero());
+                // For NULL lists, place them after the previous item's data to maintain the
+                // no-overlap invariant for zero-copy to `ListArray` arrays.
+                new_offsets.push(n_elements);
+                new_sizes.push(S::zero());
                 continue;
             }
 
-            let offset = offsets_canonical[index];
-            let size = sizes_canonical[index];
+            let offset = offsets_slice[index];
+            let size = sizes_slice[index];
 
             let start = offset.as_();
             let stop = start + size.as_();
 
-            chunks.push(elements_canonical.slice(start..stop));
-            offsets.push(n_elements);
-            sizes.push(size);
+            new_offsets.push(n_elements);
+            new_sizes.push(size);
+            new_elements_builder.extend_from_array(&elements_canonical.slice(start..stop));
 
-            n_elements += num_traits::cast(size).vortex_expect("cast");
+            n_elements += num_traits::cast(size).vortex_expect("Cast failed");
         }
 
-        let offsets = offsets.into_array();
-        let sizes = sizes.into_array();
+        let offsets = new_offsets.into_array();
+        let sizes = new_sizes.into_array();
+        let elements = new_elements_builder.finish();
 
-        // SAFETY: all chunks were sliced from the same array so have same DType.
-        let elements =
-            unsafe { ChunkedArray::new_unchecked(chunks, element_dtype.as_ref().clone()) };
+        debug_assert_eq!(
+            n_elements.as_(),
+            elements.len(),
+            "The accumulated elements somehow had the wrong length"
+        );
 
-        // SAFETY: elements are contiguous, offsets and sizes hand-built to be zero copy
-        //  to list.
+        // SAFETY:
+        // - All offsets are sequential and non-overlapping (`n_elements` tracks running total).
+        // - Each `offset[i] + size[i]` equals `offset[i+1]` for all valid indices (including null
+        //   lists).
+        // - All elements referenced by (offset, size) pairs exist within the new `elements` array.
+        // - The validity array is preserved from the original array unchanged
+        // - The array satisfies the zero-copy-to-list property by having sorted offsets, no gaps,
+        //   and no overlaps.
         unsafe {
-            ListViewArray::new_unchecked(
-                elements.to_canonical().into_array(),
-                offsets,
-                sizes,
-                self.validity.clone(),
-            )
-            .with_zero_copy_to_list(true)
+            ListViewArray::new_unchecked(elements, offsets, sizes, self.validity.clone())
+                .with_zero_copy_to_list(true)
         }
     }
 
@@ -341,5 +364,54 @@ mod tests {
         // Note that element at index 2 (97) is preserved as a gap.
         let all_elements = trimmed.elements().to_primitive();
         assert_eq!(all_elements.scalar_at(2), 97i32.into());
+    }
+
+    #[test]
+    fn test_rebuild_with_trailing_nulls_regression() {
+        // Regression test for issue #5412
+        // Tests that zero-copy-to-list arrays with trailing NULLs correctly calculate
+        // offsets for NULL items to maintain no-overlap invariant
+
+        // Create a ListViewArray with trailing NULLs
+        let elements = PrimitiveArray::from_iter(vec![1i32, 2, 3, 4]).into_array();
+        let offsets = PrimitiveArray::from_iter(vec![0u32, 2, 0, 0]).into_array();
+        let sizes = PrimitiveArray::from_iter(vec![2u32, 2, 0, 0]).into_array();
+        let validity = Validity::from_iter(vec![true, true, false, false]);
+
+        let listview = ListViewArray::new(elements, offsets, sizes, validity);
+
+        // First rebuild to make it zero-copy-to-list
+        let rebuilt = listview.rebuild(ListViewRebuildMode::MakeZeroCopyToList);
+        assert!(rebuilt.is_zero_copy_to_list());
+
+        // Verify NULL items have correct offsets (should not reuse previous offsets)
+        // After rebuild: offsets should be [0, 2, 4, 4] for zero-copy-to-list
+        assert_eq!(rebuilt.offset_at(0), 0);
+        assert_eq!(rebuilt.offset_at(1), 2);
+        assert_eq!(rebuilt.offset_at(2), 4); // NULL should be at position 4
+        assert_eq!(rebuilt.offset_at(3), 4); // Second NULL also at position 4
+
+        // All sizes should be correct
+        assert_eq!(rebuilt.size_at(0), 2);
+        assert_eq!(rebuilt.size_at(1), 2);
+        assert_eq!(rebuilt.size_at(2), 0); // NULL has size 0
+        assert_eq!(rebuilt.size_at(3), 0); // NULL has size 0
+
+        // Now rebuild with MakeExact (which calls naive_rebuild then trim_elements)
+        // This should not panic (issue #5412)
+        let exact = rebuilt.rebuild(ListViewRebuildMode::MakeExact);
+
+        // Verify the result is still valid
+        assert!(exact.is_valid(0));
+        assert!(exact.is_valid(1));
+        assert!(!exact.is_valid(2));
+        assert!(!exact.is_valid(3));
+
+        // Verify data is preserved
+        let list0 = exact.list_elements_at(0).to_primitive();
+        assert_eq!(list0.as_slice::<i32>(), &[1, 2]);
+
+        let list1 = exact.list_elements_at(1).to_primitive();
+        assert_eq!(list1.as_slice::<i32>(), &[3, 4]);
     }
 }

--- a/vortex-array/src/arrays/listview/rebuild.rs
+++ b/vortex-array/src/arrays/listview/rebuild.rs
@@ -2,14 +2,14 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use num_traits::FromPrimitive;
+use vortex_buffer::BufferMut;
 use vortex_dtype::{IntegerPType, Nullability, match_each_integer_ptype};
 use vortex_error::VortexExpect;
 use vortex_scalar::Scalar;
 
-use crate::arrays::ListViewArray;
-use crate::builders::{ArrayBuilder, ListViewBuilder};
+use crate::arrays::{ChunkedArray, ListViewArray};
 use crate::vtable::ValidityHelper;
-use crate::{Array, compute};
+use crate::{Array, IntoArray, ToCanonical, compute};
 
 /// Modes for rebuilding a [`ListViewArray`].
 pub enum ListViewRebuildMode {
@@ -74,35 +74,80 @@ impl ListViewArray {
         let offsets_ptype = self.offsets().dtype().as_ptype();
         let sizes_ptype = self.sizes().dtype().as_ptype();
 
-        match_each_integer_ptype!(offsets_ptype, |O| {
-            match_each_integer_ptype!(sizes_ptype, |S| { self.naive_rebuild::<O, S>() })
+        match_each_integer_ptype!(sizes_ptype, |S| {
+            match offsets_ptype {
+                PType::U8 => self.naive_rebuild::<u8, u32, S>(),
+                PType::U16 => self.naive_rebuild::<u16, u32, S>(),
+                PType::U32 => self.naive_rebuild::<u32, u32, S>(),
+                PType::U64 => self.naive_rebuild::<u64, u64, S>(),
+                PType::I8 => self.naive_rebuild::<i8, i32, S>(),
+                PType::I16 => self.naive_rebuild::<i16, i32, S>(),
+                PType::I32 => self.naive_rebuild::<i32, i32, S>(),
+                PType::I64 => self.naive_rebuild::<i64, i64, S>(),
+                _ => unreachable!("invalid offsets PType"),
+            }
         })
     }
 
     /// The inner function for `rebuild_zero_copy_to_list`, which naively rebuilds a `ListViewArray`
     /// via `append_scalar`.
-    fn naive_rebuild<O: IntegerPType, S: IntegerPType>(&self) -> ListViewArray {
+    fn naive_rebuild<O: IntegerPType, NewOffset: IntegerPType, S: IntegerPType>(
+        &self,
+    ) -> ListViewArray {
         let element_dtype = self
             .dtype()
             .as_list_element_opt()
             .vortex_expect("somehow had a canonical list that was not a list");
 
-        let mut builder = ListViewBuilder::<O, S>::with_capacity(
-            element_dtype.clone(),
-            self.dtype().nullability(),
-            self.elements().len(),
-            self.len(),
-        );
+        // Upfront canonicalize the list elements, we're going to be doing a lot of
+        // slicing with them.
+        let elements_canonical = self.elements().to_canonical().into_array();
+        let offsets_canonical = self.offsets().to_primitive();
+        let sizes_canonical = self.sizes().to_primitive();
 
-        for i in 0..self.len() {
-            let list = self.scalar_at(i);
+        let offsets_canonical = offsets_canonical.as_slice::<O>();
+        let sizes_canonical = sizes_canonical.as_slice::<S>();
 
-            builder
-                .append_scalar(&list)
-                .vortex_expect("was unable to extend the `ListViewBuilder`")
+        let mut offsets = BufferMut::<NewOffset>::with_capacity(self.len());
+        let mut sizes = BufferMut::<S>::with_capacity(self.len());
+
+        let mut chunks = Vec::with_capacity(self.len());
+
+        let mut n_elements = NewOffset::zero();
+
+        for index in 0..self.len() {
+            if !self.is_valid(index) {
+                offsets.push(offsets.last().copied().unwrap_or_default());
+                sizes.push(S::zero());
+                continue;
+            }
+
+            let offset = offsets_canonical[index];
+            let size = sizes_canonical[index];
+
+            let start = offset.as_();
+            let stop = start + size.as_();
+
+            chunks.push(elements_canonical.slice(start..stop));
+            offsets.push(n_elements);
+            sizes.push(size);
+
+            n_elements += num_traits::cast(size).vortex_expect("cast");
         }
 
-        builder.finish_into_listview()
+        let offsets = offsets.into_array();
+        let sizes = sizes.into_array();
+
+        // SAFETY: all chunks were sliced from the same array so have same DType.
+        let elements =
+            unsafe { ChunkedArray::new_unchecked(chunks, element_dtype.as_ref().clone()) };
+
+        ListViewArray::new(
+            elements.to_canonical().into_array(),
+            offsets,
+            sizes,
+            self.validity.clone(),
+        )
     }
 
     /// Rebuilds a [`ListViewArray`] by trimming any unused / unreferenced leading and trailing

--- a/vortex-array/src/arrays/listview/rebuild.rs
+++ b/vortex-array/src/arrays/listview/rebuild.rs
@@ -142,12 +142,17 @@ impl ListViewArray {
         let elements =
             unsafe { ChunkedArray::new_unchecked(chunks, element_dtype.as_ref().clone()) };
 
-        ListViewArray::new(
-            elements.to_canonical().into_array(),
-            offsets,
-            sizes,
-            self.validity.clone(),
-        )
+        // SAFETY: elements are contiguous, offsets and sizes hand-built to be zero copy
+        //  to list.
+        unsafe {
+            ListViewArray::new_unchecked(
+                elements.to_canonical().into_array(),
+                offsets,
+                sizes,
+                self.validity.clone(),
+            )
+            .with_zero_copy_to_list(true)
+        }
     }
 
     /// Rebuilds a [`ListViewArray`] by trimming any unused / unreferenced leading and trailing

--- a/vortex-array/src/arrays/listview/tests/basic.rs
+++ b/vortex-array/src/arrays/listview/tests/basic.rs
@@ -374,3 +374,54 @@ fn test_verify_is_zero_copy_to_list() {
     // Should return false due to overlapping list views.
     assert!(!listview.verify_is_zero_copy_to_list());
 }
+
+#[test]
+#[should_panic(expected = "Zero-copy-to-list requires views to be non-overlapping and ordered")]
+fn test_validate_monotonic_ends_with_nulls() {
+    // Regression test for issue #5412
+    // Tests that validate_zctl catches incorrect NULL offsets
+
+    // Create an array with buggy NULL offsets (as would be produced by the old naive_rebuild)
+    // Elements: [1, 2, 3, 4]
+    // View 0: [1, 2] at offset 0
+    // View 1: [3, 4] at offset 2
+    // View 2 (NULL): incorrectly at offset 2 (should be 4)
+    let elements = buffer![1i32, 2, 3, 4].into_array();
+    let offsets = buffer![0u32, 2, 2].into_array(); // Bug: NULL reuses offset 2
+    let sizes = buffer![2u32, 2, 0].into_array();
+    let validity = Validity::from_iter(vec![true, true, false]);
+
+    let listview = ListViewArray::new(elements, offsets, sizes, validity);
+
+    // The array itself is valid (can be constructed)
+    assert_eq!(listview.len(), 3);
+
+    // But it should NOT be valid as zero-copy-to-list due to the monotonic violation
+    // offset[1] + size[1] = 2 + 2 = 4, but offset[2] = 2, violating 4 <= 2
+    // This should panic with our new monotonic check
+    unsafe {
+        let _zctl = listview.with_zero_copy_to_list(true);
+    }
+}
+
+#[test]
+fn test_validate_monotonic_ends_correct_nulls() {
+    // Test that correctly placed NULLs pass validation
+    // Elements: [1, 2, 3, 4]
+    // View 0: [1, 2] at offset 0
+    // View 1: [3, 4] at offset 2
+    // View 2 (NULL): correctly at offset 4 (after all data)
+    let elements = buffer![1i32, 2, 3, 4].into_array();
+    let offsets = buffer![0u32, 2, 4].into_array(); // Correct: NULL at position 4
+    let sizes = buffer![2u32, 2, 0].into_array();
+    let validity = Validity::from_iter(vec![true, true, false]);
+
+    let listview = ListViewArray::new(elements, offsets, sizes, validity);
+
+    // Should be valid as zero-copy-to-list - this should NOT panic
+    let zctl_listview = unsafe { listview.clone().with_zero_copy_to_list(true) };
+    assert!(zctl_listview.is_zero_copy_to_list());
+
+    // verify_is_zero_copy_to_list should also return true
+    assert!(listview.verify_is_zero_copy_to_list());
+}

--- a/vortex-array/src/arrow/compute/to_arrow/canonical.rs
+++ b/vortex-array/src/arrow/compute/to_arrow/canonical.rs
@@ -1026,7 +1026,7 @@ mod tests {
     fn test_to_arrow_listview_i64() {
         // Create a ListViewArray with nullable elements: [[100], null, [200, 300]]
         let elements = PrimitiveArray::new(buffer![100i64, 200, 300], Validity::NonNullable);
-        let offsets = PrimitiveArray::new(buffer![0i64, 0, 1], Validity::NonNullable);
+        let offsets = PrimitiveArray::new(buffer![0i64, 1, 1], Validity::NonNullable);
         let sizes = PrimitiveArray::new(buffer![1i64, 0, 2], Validity::NonNullable);
         let validity = Validity::from_iter([true, false, true]);
 

--- a/vortex-array/src/builders/listview.rs
+++ b/vortex-array/src/builders/listview.rs
@@ -77,17 +77,6 @@ impl<O: IntegerPType, S: IntegerPType> ListViewBuilder<O, S> {
         elements_capacity: usize,
         capacity: usize,
     ) -> Self {
-        // Validate that size type's maximum value fits within offset type's maximum value.
-        // Since offsets are non-negative, we only need to check max values.
-        assert!(
-            S::max_value_as_u64() <= O::max_value_as_u64(),
-            "Size type {:?} (max offset {}) must fit within offset type {:?} (max offset {})",
-            S::PTYPE,
-            S::max_value_as_u64(),
-            O::PTYPE,
-            O::max_value_as_u64()
-        );
-
         let elements_builder = builder_with_capacity(&element_dtype, elements_capacity);
 
         let offsets_builder =
@@ -627,15 +616,5 @@ mod tests {
                 .to_string()
                 .contains("null value to non-nullable")
         );
-    }
-
-    #[test]
-    #[should_panic(
-        expected = "Size type I32 (max offset 2147483647) must fit within offset type I16 (max offset 32767)"
-    )]
-    fn test_error_invalid_type_combination() {
-        let dtype: Arc<DType> = Arc::new(I32.into());
-        // This should panic because i32 (4 bytes) cannot fit within i16 (2 bytes).
-        let _builder = ListViewBuilder::<i16, i32>::with_capacity(dtype, NonNullable, 0, 0);
     }
 }

--- a/vortex-datafusion/src/persistent/opener.rs
+++ b/vortex-datafusion/src/persistent/opener.rs
@@ -227,8 +227,10 @@ impl FileOpener for VortexOpener {
                 // for schema evolution and divergence between the table's schema and individual files.
                 filter = filter
                     .map(|filter| {
-                        let logical_file_schema =
-                            compute_logical_file_schema(&physical_file_schema, &logical_schema);
+                        let logical_file_schema = compute_logical_file_schema(
+                            &physical_file_schema.clone(),
+                            &logical_schema,
+                        );
 
                         let expr = expr_adapter_factory
                             .create(logical_file_schema, physical_file_schema.clone())
@@ -244,9 +246,14 @@ impl FileOpener for VortexOpener {
                 predicate_file_schema = physical_file_schema.clone();
             }
 
-            let (schema_mapping, adapted_projections) =
+            // Create the initial mapping from physical file schema to projected schema.
+            // This gives us the field reordering and tells us which logical schema fields
+            // to select.
+            let (_schema_mapping, adapted_projections) =
                 schema_adapter.map_schema(&physical_file_schema)?;
 
+            // Build the Vortex projection expression using the adapted projections.
+            // This will reorder the fields to match the target order.
             let fields = adapted_projections
                 .iter()
                 .map(|idx| {
@@ -255,6 +262,39 @@ impl FileOpener for VortexOpener {
                 })
                 .collect::<Vec<_>>();
             let projection_expr = select(fields, root());
+
+            // After Vortex applies the projection, the batch will have fields in the target
+            // order (matching adapted_projections), but with the physical file types.
+            // We need a second schema mapping for type casting only, not reordering.
+            // Build a schema that represents what Vortex will return: fields in target order
+            // with physical types.
+            let projected_physical_fields: Vec<Field> = adapted_projections
+                .iter()
+                .map(|&idx| {
+                    let logical_field = logical_schema.field(idx);
+                    let field_name = logical_field.name();
+
+                    // Find this field in the physical schema to get its physical type
+                    physical_file_schema
+                        .field_with_name(field_name)
+                        .map(|phys_field| {
+                            Field::new(
+                                field_name,
+                                merge_field_types(phys_field, logical_field),
+                                phys_field.is_nullable(),
+                            )
+                        })
+                        .unwrap_or_else(|_| (*logical_field).clone())
+                })
+                .collect();
+
+            let projected_physical_schema =
+                Arc::new(arrow_schema::Schema::new(projected_physical_fields));
+
+            // Create a second mapping from the projected physical schema (what Vortex returns)
+            // to the final projected schema. This mapping will handle type casting without reordering.
+            let (batch_schema_mapping, _) =
+                schema_adapter.map_schema(&projected_physical_schema)?;
 
             // We share our layout readers with others partitions in the scan, so we can only need to read each layout in each file once.
             let layout_reader = match layout_reader.entry(file_meta.object_meta.location.clone()) {
@@ -350,7 +390,7 @@ impl FileOpener for VortexOpener {
                     ))))
                 })
                 .try_flatten()
-                .map(move |batch| batch.and_then(|b| schema_mapping.map_batch(b)))
+                .map(move |batch| batch.and_then(|b| batch_schema_mapping.map_batch(b)))
                 .boxed();
 
             Ok(stream)
@@ -653,6 +693,74 @@ mod tests {
         | -2    |
         | -3    |
         +-------+
+        ");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    // This test verifies that files with different column order than the
+    // table schema can be opened without errors. The fix ensures that the
+    // schema mapper is only used for type casting, not for reordering,
+    // since the vortex projection already handles reordering.
+    async fn test_schema_different_column_order() -> anyhow::Result<()> {
+        use datafusion::arrow::util::pretty::pretty_format_batches_with_options;
+
+        let object_store = Arc::new(InMemory::new()) as Arc<dyn ObjectStore>;
+        let file_path = "/path/file.vortex";
+
+        // File has columns in order: c, b, a
+        let batch = record_batch!(
+            ("c", Int32, vec![Some(300), Some(301), Some(302)]),
+            ("b", Int32, vec![Some(200), Some(201), Some(202)]),
+            ("a", Int32, vec![Some(100), Some(101), Some(102)])
+        )
+        .unwrap();
+        let data_size = write_arrow_to_vortex(object_store.clone(), file_path, batch).await?;
+        let file = PartitionedFile::new(file_path.to_string(), data_size);
+
+        // Table schema has columns in different order: a, b, c
+        let table_schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, true),
+            Field::new("b", DataType::Int32, true),
+            Field::new("c", DataType::Int32, true),
+        ]));
+
+        let opener = VortexOpener {
+            session: SESSION.clone(),
+            object_store: object_store.clone(),
+            projection: Some([0, 1, 2].into()),
+            filter: None,
+            file_pruning_predicate: None,
+            expr_adapter_factory: Some(Arc::new(DefaultPhysicalExprAdapterFactory) as _),
+            schema_adapter_factory: Arc::new(DefaultSchemaAdapterFactory),
+            partition_fields: vec![],
+            file_cache: VortexFileCache::new(1, 1, SESSION.clone()),
+            logical_schema: table_schema.clone(),
+            batch_size: 100,
+            limit: None,
+            metrics: Default::default(),
+            layout_readers: Default::default(),
+            has_output_ordering: false,
+        };
+
+        // The opener should successfully open the file and reorder columns
+        let stream = opener.open(make_meta(file_path, data_size), file)?.await?;
+
+        let format_opts = FormatOptions::new().with_types_info(true);
+        let data = stream.try_collect::<Vec<_>>().await?;
+
+        // Verify the output has columns in table schema order (a, b, c)
+        // not file order (c, b, a)
+        assert_snapshot!(pretty_format_batches_with_options(&data, &format_opts)?.to_string(), @r"
+        +-------+-------+-------+
+        | a     | b     | c     |
+        | Int32 | Int32 | Int32 |
+        +-------+-------+-------+
+        | 100   | 200   | 300   |
+        | 101   | 201   | 301   |
+        | 102   | 202   | 302   |
+        +-------+-------+-------+
         ");
 
         Ok(())


### PR DESCRIPTION
In #4946, we forced rebuilding ListView arrays that were being built.

A user report came in with a 10x performance regression with lots of time being spent inside of ZSTD decompression. On further investigation, the flame graph clarified that inside of a file scan, we were filtering a ListView array, where the elements were ZSTD compressed. Calling `naive_rebuild` goes through an awful `append_scalar` pathway, and `scalar_at` for ZSTD...decompresses a whole frame.

To avoid this, we fully canonicalize the elements, offsets, and sizes in bulk, then stitch a new ListView from the components.

This is 10-20x faster than the previous codepath, per the added benchmark.


Before:

```
Timer precision: 41 ns
listview_rebuild  fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ rebuild_naive  1.821 ms      │ 2.535 ms      │ 2.019 ms      │ 2.024 ms      │ 100     │ 100
```

After:

```
Timer precision: 41 ns
listview_rebuild  fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ rebuild_naive  109.5 µs      │ 192.2 µs      │ 121.1 µs      │ 122 µs        │ 100     │ 100
```

---------