### PR TITLE
fix[vortex-array]: fix take on varbinviews with NULL indices

### DIFF
--- a/docs/specs/file-format.md
+++ b/docs/specs/file-format.md
@@ -117,26 +117,3 @@ The plan is that at write-time, a minimum supported reader version is declared. 
 reader version can then be embedded into the file with WebAssembly decompression logic. Old readers are able to decompress new
 data (slower than native code, but still with SIMD acceleration) and read the file. New readers are able to make the best use of
 these encodings with native decompression logic and additional push-down compute functions (which also provides an incentive to upgrade).
-
-## File Determinism and Reproducibility
-
-### Encoding Order Indeterminism
-
-When writing Vortex files, each array segment references its encoding via an integer index into the footer's `array_specs`
-list. During serialization, encodings are registered in the order they are first encountered via calls to
-`ArrayContext::encoding_idx()`. With concurrent writes, this encounter order depends on thread scheduling and lock
-acquisition timing, making the ordering in the footer non-deterministic between runs.
-
-This affects the `encoding` field in each serialized array segment. The same encoding might receive index 0 in one run and
-index 1 in another, changing the integer value stored in each array segment that uses that encoding. FlatBuffers optimize
-storage by omitting fields with default values (such as 0), so when an encoding index is 0, the field may be omitted from
-the serialized representation. This saves approximately 2 bytes per affected array segment, and with alignment adjustments,
-can result in up to 4 bytes difference per array segment between runs.
-
-:::{note}
-Despite this non-determinism, the practical impact is minimal:
-
-- File size may vary by up to 4 bytes per affected array segment
-- All file contents remain semantically identical and fully readable
-- Segment ordering (the actual data layout) remains deterministic and consistent across writes
-:::

--- a/vortex-array/src/arrays/varbinview/compute/take.rs
+++ b/vortex-array/src/arrays/varbinview/compute/take.rs
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::iter;
 use std::ops::Deref;
 
 use num_traits::AsPrimitive;
 use vortex_buffer::Buffer;
 use vortex_dtype::match_each_integer_ptype;
 use vortex_error::VortexResult;
+use vortex_mask::AllOr;
+use vortex_mask::Mask;
 use vortex_vector::binaryview::BinaryView;
 
 use crate::arrays::{VarBinViewArray, VarBinViewVTable};
@@ -17,16 +20,16 @@ use crate::{Array, ArrayRef, IntoArray, ToCanonical, register_kernel};
 /// Take involves creating a new array that references the old array, just with the given set of views.
 impl TakeKernel for VarBinViewVTable {
     fn take(&self, array: &VarBinViewArray, indices: &dyn Array) -> VortexResult<ArrayRef> {
-        // Compute the new validity
-
-        // This is valid since all elements (of all arrays) even null values must be inside
-        // min-max valid range.
+        // Compute the new validity.
         let validity = array.validity().take(indices)?;
         let indices = indices.to_primitive();
 
         let views_buffer = match_each_integer_ptype!(indices.ptype(), |I| {
-            // This is valid since all elements even null values are inside the min-max valid range.
-            take_views(array.views(), indices.as_slice::<I>())
+            take_views(
+                array.views(),
+                indices.as_slice::<I>(),
+                &indices.validity_mask(),
+            )
         });
 
         // SAFETY: taking all components at same indices maintains invariants
@@ -49,15 +52,36 @@ register_kernel!(TakeKernelAdapter(VarBinViewVTable).lift());
 fn take_views<I: AsPrimitive<usize>>(
     views: &Buffer<BinaryView>,
     indices: &[I],
+    mask: &Mask,
 ) -> Buffer<BinaryView> {
     // NOTE(ngates): this deref is not actually trivial, so we run it once.
     let views_ref = views.deref();
-    Buffer::<BinaryView>::from_trusted_len_iter(indices.iter().map(|i| views_ref[i.as_()]))
+    // We do not use iter_bools directly, since the resulting dyn iterator cannot
+    // implement TrustedLen.
+    match mask.bit_buffer() {
+        AllOr::All => {
+            Buffer::<BinaryView>::from_trusted_len_iter(indices.iter().map(|i| views_ref[i.as_()]))
+        }
+        AllOr::None => Buffer::<BinaryView>::from_trusted_len_iter(iter::repeat_n(
+            BinaryView::default(),
+            indices.len(),
+        )),
+        AllOr::Some(buffer) => Buffer::<BinaryView>::from_trusted_len_iter(
+            buffer.iter().zip(indices.iter()).map(|(valid, idx)| {
+                if valid {
+                    views_ref[idx.as_()]
+                } else {
+                    BinaryView::default()
+                }
+            }),
+        ),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
+    use vortex_buffer::BitBuffer;
     use vortex_buffer::buffer;
     use vortex_dtype::DType;
     use vortex_dtype::Nullability::NonNullable;
@@ -69,6 +93,7 @@ mod tests {
     use crate::canonical::ToCanonical;
     use crate::compute::conformance::take::test_take_conformance;
     use crate::compute::take;
+    use crate::validity::Validity;
 
     #[test]
     fn take_nullable() {
@@ -96,11 +121,13 @@ mod tests {
     fn take_nullable_indices() {
         let arr = VarBinViewArray::from_iter(["one", "two"].map(Some), DType::Utf8(NonNullable));
 
-        let taken = take(
-            arr.as_ref(),
-            PrimitiveArray::from_option_iter(vec![Some(1), None]).as_ref(),
-        )
-        .unwrap();
+        let indices = PrimitiveArray::new(
+            // Verify that garbage values at NULL indices are ignored.
+            buffer![1u64, 999],
+            Validity::from(BitBuffer::from(vec![true, false])),
+        );
+
+        let taken = take(arr.as_ref(), indices.as_ref()).unwrap();
 
         assert!(taken.dtype().is_nullable());
         assert_eq!(

--- a/vortex-array/src/context.rs
+++ b/vortex-array/src/context.rs
@@ -23,6 +23,15 @@ impl<T: Clone + Eq> VTableContext<T> {
         Self(Arc::new(RwLock::new(encodings)))
     }
 
+    pub fn from_registry_sorted(registry: &Registry<T>) -> Self
+    where
+        T: Display,
+    {
+        let mut encodings: Vec<T> = registry.items().collect();
+        encodings.sort_by_key(|a| a.to_string());
+        Self::new(encodings)
+    }
+
     pub fn try_from_registry<'a>(
         registry: &Registry<T>,
         ids: impl IntoIterator<Item = &'a str>,

--- a/vortex-buffer/src/trusted_len.rs
+++ b/vortex-buffer/src/trusted_len.rs
@@ -161,6 +161,9 @@ where
 {
 }
 
+unsafe impl<T: Clone> TrustedLen for std::iter::RepeatN<T> {}
+
 // Arrow bit iterators
 unsafe impl<'a> TrustedLen for crate::bit::BitChunkIterator<'a> {}
 unsafe impl<'a> TrustedLen for crate::bit::UnalignedBitChunkIterator<'a> {}
+unsafe impl<'a> TrustedLen for crate::bit::BitIterator<'a> {}

--- a/vortex-file/src/writer.rs
+++ b/vortex-file/src/writer.rs
@@ -6,12 +6,25 @@ use std::io::Write;
 use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
 
-use futures::future::{Fuse, LocalBoxFuture, ready};
-use futures::{FutureExt, StreamExt, TryStreamExt, pin_mut, select};
-use vortex_array::iter::{ArrayIterator, ArrayIteratorExt};
-use vortex_array::stats::{PRUNING_STATS, Stat};
-use vortex_array::stream::{ArrayStream, ArrayStreamAdapter, ArrayStreamExt, SendableArrayStream};
-use vortex_array::{ArrayContext, ArrayRef};
+use futures::FutureExt;
+use futures::StreamExt;
+use futures::TryStreamExt;
+use futures::future::Fuse;
+use futures::future::LocalBoxFuture;
+use futures::future::ready;
+use futures::pin_mut;
+use futures::select;
+use vortex_array::ArrayContext;
+use vortex_array::ArrayRef;
+use vortex_array::iter::ArrayIterator;
+use vortex_array::iter::ArrayIteratorExt;
+use vortex_array::ArraySessionExt;
+use vortex_array::stats::PRUNING_STATS;
+use vortex_array::stats::Stat;
+use vortex_array::stream::ArrayStream;
+use vortex_array::stream::ArrayStreamAdapter;
+use vortex_array::stream::ArrayStreamExt;
+use vortex_array::stream::SendableArrayStream;
 use vortex_buffer::ByteBuffer;
 use vortex_dtype::DType;
 use vortex_error::{VortexError, VortexExpect, VortexResult, vortex_bail, vortex_err};
@@ -116,8 +129,12 @@ impl VortexWriteOptions {
         mut write: W,
         stream: SendableArrayStream,
     ) -> VortexResult<WriteSummary> {
-        // Set up a Context to capture the encodings used in the file.
-        let ctx = ArrayContext::empty();
+        // NOTE(os): Setup an array context that already has all known encodings pre-populated.
+        // This is preferred for now over having an empty context here, because only the
+        // serialised array order is deterministic. The serialisation of arrays are done
+        // parallel and with an empty context they can register their encodings to the context
+        // in different order, changing the written bytes from run to run.
+        let ctx = ArrayContext::from_registry_sorted(self.session.arrays().registry());
         let dtype = stream.dtype().clone();
 
         let (mut ptr, eof) = SequenceId::root().split();

--- a/vortex-python/src/io.rs
+++ b/vortex-python/src/io.rs
@@ -212,7 +212,7 @@ impl PyVortexWriteOptions {
     /// >>> vx.io.VortexWriteOptions.default().write_path(sprl, "chonky.vortex")
     /// >>> import os
     /// >>> os.path.getsize('chonky.vortex')
-    /// 215196
+    /// 215996
     /// ```
     ///
     /// Wow, Vortex manages to use about two bytes per integer! So advanced. So tiny.
@@ -224,7 +224,7 @@ impl PyVortexWriteOptions {
     /// ```python
     /// >>> vx.io.VortexWriteOptions.compact().write_path(sprl, "tiny.vortex")
     /// >>> os.path.getsize('tiny.vortex')
-    /// 54200
+    /// 55116
     /// ```
     ///
     /// Random numbers are not (usually) composed of random bytes!


### PR DESCRIPTION
Index values at NULL positions were used. In the case that these were garbage, an OOB panic would occur.